### PR TITLE
🔧 Bessere Dependency-Namen für Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,8 +34,8 @@
       "customType": "regex",
       "managerFilePatterns": ["/^plugin-data\\/.*\\.json$/"],
       "matchStrings": [
-        "\"sourceUrl\"\\s*:\\s*\"https:\\/\\/github\\.com\\/(?<depName>[^\\/]+\\/[^\\/\"]+)\"[\\s\\S]*?\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\"",
-        "\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\"[\\s\\S]*?\"sourceUrl\"\\s*:\\s*\"https:\\/\\/github\\.com\\/(?<depName>[^\\/]+\\/[^\\/\"]+)\""
+        "\"sourceUrl\"\\s*:\\s*\"https:\\/\\/github\\.com\\/(?<packageName>[^\\/]+\\/(?<depName>[^\\/\"]+))\"[\\s\\S]*?\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\"",
+        "\"version\"\\s*:\\s*\"(?<currentValue>[^\"]+)\"[\\s\\S]*?\"sourceUrl\"\\s*:\\s*\"https:\\/\\/github\\.com\\/(?<packageName>[^\\/]+\\/(?<depName>[^\\/\"]+))\""
       ],
       "packageNameTemplate": "{{depName}}",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
- Unterscheidung zwischen technischem packageName und anzuzeigendem depName